### PR TITLE
Build image for arm64

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -5,6 +5,7 @@ def main(ctx):
 
   arches = [
     'amd64',
+    'arm64v8',
   ]
 
   config = {

--- a/latest/Dockerfile.arm64v8
+++ b/latest/Dockerfile.arm64v8
@@ -1,0 +1,27 @@
+FROM alpine:3.18
+
+LABEL maintainer="ownCloud DevOps <devops@owncloud.com>"
+LABEL org.opencontainers.image.authors="ownCloud DevOps <devops@owncloud.com>"
+LABEL org.opencontainers.image.title="ownCloud CI ClamAV"
+LABEL org.opencontainers.image.url="https://github.com/owncloud-ci/clamavd"
+LABEL org.opencontainers.image.source="https://github.com/owncloud-ci/clamavd"
+LABEL org.opencontainers.image.documentation="https://github.com/owncloud-ci/clamavd"
+
+RUN apk add --update bash clamav clamav-libunrar && \
+    rm -fr /var/cache/apk/*
+
+RUN mkdir /run/clamav && \
+    chown clamav:clamav /run/clamav && \
+    chmod 750 /run/clamav
+
+RUN freshclam
+
+RUN echo "Foreground true" >> /etc/clamav/clamd.conf && \
+    echo "TCPSocket 3310" >> /etc/clamav/clamd.conf && \
+    echo "Foreground true" >> /etc/clamav/freshclam.conf
+
+EXPOSE 3310
+
+ADD run.sh /
+
+CMD ["/run.sh"]

--- a/latest/manifest.tmpl
+++ b/latest/manifest.tmpl
@@ -4,3 +4,8 @@ manifests:
     platform:
       architecture: amd64
       os: linux
+  - image: owncloudci/clamavd:arm64v8
+    platform:
+      architecture: arm64
+      variant: v8
+      os: linux


### PR DESCRIPTION
We also need arm64 version of this image for some use cases like https://github.com/owncloud/ocis/pull/6588#issue-1768965892 for macOS devices.

Currently, using `mkodockx/docker-clamav`.

CC @xoxys 